### PR TITLE
fixes unbalanced backticks in docstrings; replaces explicit type with Self keyword based on rust analyzer

### DIFF
--- a/common/src/tools.rs
+++ b/common/src/tools.rs
@@ -43,7 +43,7 @@ impl RandScalar for c32 {
         rng: &mut R,
         dist: &D,
     ) -> Self {
-        c32::new(dist.sample(rng), dist.sample(rng))
+        Self::new(dist.sample(rng), dist.sample(rng))
     }
 }
 
@@ -52,7 +52,7 @@ impl RandScalar for c64 {
         rng: &mut R,
         dist: &D,
     ) -> Self {
-        c64::new(dist.sample(rng), dist.sample(rng))
+        Self::new(dist.sample(rng), dist.sample(rng))
     }
 }
 

--- a/common/src/traits/accessors.rs
+++ b/common/src/traits/accessors.rs
@@ -12,7 +12,7 @@
 //! corresponding bounds-checked traits [`RandomAccessByValue`], [`RandomAccessByRef`] and
 //! [`RandomAccessMut`] are auto-implemented.
 //!
-//! To get raw access to the underlying data use the [`RawAccess`] and ['RawAccessMut`] traits.
+//! To get raw access to the underlying data use the [`RawAccess`] and [`RawAccessMut`] traits.
 
 use crate::traits::properties::{NumberOfElements, Shape};
 use crate::types::Scalar;

--- a/common/src/traits/operations.rs
+++ b/common/src/traits/operations.rs
@@ -49,7 +49,7 @@ pub trait Inner {
 
 /// Compute a dual form of an object with `other`.
 /// The convention for complex objecdts is that the complex-conjugate
-/// of `other is taken when appropriate for the dual form.
+/// of `other` is taken when appropriate for the dual form.
 pub trait Dual {
     type T: Scalar;
     type Other;


### PR DESCRIPTION
- fixes unbalanced backticks in docstrings
- replaces explicit type with Self keyword based on rust analyzer