### PR TITLE
Updates the lapack-src crate dependency to version 0.9

### DIFF
--- a/algorithms/Cargo.toml
+++ b/algorithms/Cargo.toml
@@ -15,7 +15,7 @@ rlst-dense = {path = "../dense"}
 num = "0.4"
 rand = "0.8"
 lapacke = { version = "0.5"}
-lapack-src = { version = "0.8", features = ["openblas"]}
+lapack-src = { version = "0.9", features = ["openblas"]}
 rand_chacha = "0.3"
 approx = { version = "0.5", features=["num-complex"] }
 openblas-src = { version = "0.10", features = ["system"], optional = true }


### PR DESCRIPTION
Version 0.9 of the upsteam `lapack-src` crate was released two days ago. This PR bumps up the version of the dependency for our library.

Have tried it locally and it works, and all tests pass. The CI should also pass.